### PR TITLE
Examples updates

### DIFF
--- a/examples/2005-animation-speed.example
+++ b/examples/2005-animation-speed.example
@@ -21,7 +21,7 @@ var board = Chessboard2('myBoard', {
   position: 'start'
 })
 
-$('#ruyLopezBtn').on('click', function () {
-  board.position('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R')
+attachEvent('ruyLopezBtn', 'click', function () {
+    board.position('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R')
 })
-$('#startBtn').on('click', board.start)
+attachEvent('startBtn', 'click', board.start)

--- a/examples/2006-spare-pieces.example
+++ b/examples/2006-spare-pieces.example
@@ -19,5 +19,5 @@ var board = Chessboard2('myBoard', {
   sparePieces: true
 })
 
-$('#startBtn').on('click', board.start)
-$('#clearBtn').on('click', board.clear)
+attachEvent('startBtn', 'click', board.start)
+attachEvent('clearBtn', 'click', board.clear)

--- a/examples/3002-set-position-instant.example
+++ b/examples/3002-set-position-instant.example
@@ -20,15 +20,15 @@ Pass <code class="js keyword">false</code> as the second argument to the <a href
 ===== JS
 var board = Chessboard2('myBoard')
 
-$('#setStartBtn').on('click', function() {
+attachEvent('setStartBtn', 'click', function() {
   board.start(false)
 })
 
-$('#setRuyLopezBtn').on('click', function () {
+attachEvent('setRuyLopezBtn', 'click', function () {
   board.position('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R', false)
 })
 
-$('#setRookCheckmateBtn').on('click', function () {
+attachEvent('setRookCheckmateBtn', 'click', function () {
   board.position({
     a4: 'bK',
     c4: 'wK',
@@ -36,7 +36,7 @@ $('#setRookCheckmateBtn').on('click', function () {
   }, false)
 })
 
-$('#setPawns1').on('click', function () {
+attachEvent('setPawns1', 'click', function () {
   board.position({
     a1: 'wP', b1: 'wP', c1: 'wP', d1: 'wP', e1: 'wP', f1: 'wP', g1: 'wP', h1: 'wP',
     a2: 'wP', b2: 'wP', c2: 'wP', d2: 'wP', e2: 'wP', f2: 'wP', g2: 'wP', h2: 'wP',
@@ -50,7 +50,7 @@ $('#setPawns1').on('click', function () {
   }, false)
 })
 
-$('#setPawns2').on('click', function () {
+attachEvent('setPawns2', 'click', function () {
   board.position({
     a5: 'wP', b5: 'wP', c5: 'wP', d5: 'wP', e5: 'wP', f5: 'wP', g5: 'wP', h5: 'wP',
     a6: 'wP', b6: 'wP', c6: 'wP', d6: 'wP', e6: 'wP', f6: 'wP', g6: 'wP', h6: 'wP',
@@ -59,7 +59,7 @@ $('#setPawns2').on('click', function () {
   }, false)
 })
 
-$('#setPawns3').on('click', function () {
+attachEvent('setPawns3', 'click', function () {
   board.position({
     a1: 'bP', b1: 'bP', c1: 'bP', d1: 'bP', e1: 'bP', f1: 'bP', g1: 'bP', h1: 'bP',
     a2: 'bP', b2: 'bP', c2: 'bP', d2: 'bP', e2: 'bP', f2: 'bP', g2: 'bP', h2: 'bP',

--- a/examples/3005-orientation.example
+++ b/examples/3005-orientation.example
@@ -21,21 +21,21 @@ const board = Chessboard2('myBoard', ruyLopez)
 board.addArrow('a7-a6', 'small')
 board.addCircle('a4')
 
-$('#flipOrientationBtn').on('click', function () {
+attachEvent('flipOrientationBtn', 'click', function () {
   const newOrientation = board.flip()
   console.log('New board orientation is:', newOrientation)
 })
 
-$('#whiteOrientationBtn').on('click', function () {
+attachEvent('whiteOrientationBtn', 'click', function () {
   const newOrientation = board.orientation('white')
   console.log('New board orientation is:', newOrientation)
 })
 
-$('#blackOrientationBtn').on('click', function () {
+attachEvent('blackOrientationBtn', 'click', function () {
   const newOrientation = board.orientation('black')
   console.log('New board orientation is:', newOrientation)
 })
 
-$('#showOrientationBtn').on('click', function () {
+attachEvent('showOrientationBtn', 'click', function () {
   console.log('Current board orientation is:', board.orientation())
 })

--- a/examples/3006-destroy.example
+++ b/examples/3006-destroy.example
@@ -14,4 +14,4 @@ Use the <a href="docs.html#methods:destroy"><code class="js plain">destroy</code
 ===== JS
 var board = Chessboard2('myBoard', 'start')
 
-$('#destroyBtn').on('click', board.destroy)
+attachEvent('destroyBtn', 'click', board.destroy)

--- a/examples/3007-resize.example
+++ b/examples/3007-resize.example
@@ -13,4 +13,4 @@ Use the <a href="docs.html#methods:resize"><code class="js plain">resize</code><
 ===== JS
 // NOTE: click "View example in new window." to see the full effect of this example
 var board = Chessboard2('myBoard', 'start')
-$(window).resize(board.resize)
+window.addEventListener('resize', board.resize)

--- a/examples/3009-circles.example
+++ b/examples/3009-circles.example
@@ -26,23 +26,26 @@ let circle1Id = null
 let circle2Id = null
 let circle3Id = null
 let circle4Id = null
+let circle5Id = null
 
 attachEvent('addCircle1Btn', 'click', () => {
   circle1Id = board.addCircle('d4')
+  console.log('added Circle 1 with id:', circle1Id)
 })
 
 attachEvent('addCircle2Btn', 'click', () => {
   circle2Id = board.addCircle('e4', 'orange', 'large')
-  // console.log('added "small" Circle 2 with id:', circle2Id)
+  console.log('added "small" Circle 2 with id:', circle2Id)
 })
 
 attachEvent('addCircle3Btn', 'click', () => {
   circle3Id = board.addCircle('e4', 'purple', 'small')
+  console.log('added "small" Circle 3 with id:', circle3Id)
 })
 
 attachEvent('addCircle4Btn', 'click', () => {
   circle4Id = board.addCircle('d5', '#8e8e8e', 'medium')
-  // console.log('added "large" Circle 4 with id:', circle4Id)
+  console.log('added "large" Circle 4 with id:', circle4Id)
 })
 
 attachEvent('addCircle5Btn', 'click', () => {

--- a/examples/3010-items.example
+++ b/examples/3010-items.example
@@ -19,7 +19,7 @@ TODO: write me :)
 ===== JS
 const board = Chessboard2('myBoard', 'start')
 
-$('#addArrowsBtn').on('click', function () {
+attachEvent('addArrowsBtn', 'click', function () {
   board.addArrow('e2-e4')
   board.addArrow('c7-c5', 'small')
   board.addArrow('a3-c3', 'medium')
@@ -27,15 +27,15 @@ $('#addArrowsBtn').on('click', function () {
   board.addArrow('g1-h3', 'large')
 })
 
-$('#itemsBtn1').on('click', function () {
+attachEvent('itemsBtn1', 'click', function () {
   console.log(board.items())
 })
 
-$('#itemsBtn2').on('click', function () {
+attachEvent('itemsBtn2', 'click', function () {
   console.log(board.getItems())
 })
 
-$('#itemsBtn3').on('click', function () {
+attachEvent('itemsBtn3', 'click', function () {
   console.log('Items Array:')
   console.log(board.getItems())
 
@@ -48,5 +48,5 @@ $('#itemsBtn3').on('click', function () {
   console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
 })
 
-$('#flipBoardBtn').on('click', board.flip)
-$('#clearArrowsBtn').on('click', board.clearArrows)
+attachEvent('flipBoardBtn', 'click', board.flip)
+attachEvent('clearArrowsBtn', 'click', board.clearArrows)

--- a/examples/3011-pieces.example
+++ b/examples/3011-pieces.example
@@ -22,35 +22,35 @@ that removing pieces from the board changes the board's position.
 ===== JS
 const board = Chessboard2('myBoard', 'start')
 
-$('#btn1').on('click', function () {
+attachEvent('btn1', 'click', function () {
   board.removePiece('a1')
 })
 
-$('#btn2').on('click', function () {
+attachEvent('btn2', 'click', function () {
   board.removePiece('d1', 'e1', 'f1')
 })
 
-$('#btn3').on('click', function () {
+attachEvent('btn3', 'click', function () {
   // pass false to disable animations
   board.removePiece('c7', false)
 })
 
-$('#addBtn1').on('click', function () {
+attachEvent('addBtn1', 'click', function () {
   board.addPiece('e4', 'wR')
 })
 
-$('#addBtn2').on('click', function () {
+attachEvent('addBtn2', 'click', function () {
   // pass false to disable animations
   board.addPiece('d5', 'bN', false)
 })
 
-$('#addBtn3').on('click', function () {
+attachEvent('addBtn3', 'click', function () {
   board.addPiece({
     piece: 'wQ',
     square: 'a5'
   })
 })
 
-$('#btnStart').on('click', function () {
+attachEvent('btnStart', 'click', function () {
   board.start()
 })

--- a/examples/3012-notation.example
+++ b/examples/3012-notation.example
@@ -31,15 +31,15 @@ const board = Chessboard2('myBoard', {
   position: { e3: 'wK', d5: 'bK', c4: 'bR' }
 })
 
-$('#showCoordinatesBtn').on('click', function () {
+attachEvent('showCoordinatesBtn', 'click', function () {
   board.showCoordinates()
 })
 
-$('#hideCoordinatesBtn').on('click', function () {
+attachEvent('hideCoordinatesBtn', 'click', function () {
   board.hideCoordinates()
 })
 
-$('#toggleCoordinatesBtn').on('click', function () {
+attachEvent('toggleCoordinatesBtn', 'click', function () {
   board.toggleCoordinates()
 })
 

--- a/examples/4000-onchange.example
+++ b/examples/4000-onchange.example
@@ -27,9 +27,9 @@ var config = {
 }
 var board = Chessboard2('myBoard', config)
 
-$('#ruyLopezBtn').on('click', function () {
+attachEvent('ruyLopezBtn', 'click', function () {
   var ruyLopez = 'r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R'
   board.position(ruyLopez)
 })
 
-$('#startPositionBtn').on('click', board.start)
+attachEvent('startPositionBtn', 'click', board.start)

--- a/examples/4002-ondragstart-prevent-drag.example
+++ b/examples/4002-ondragstart-prevent-drag.example
@@ -28,4 +28,4 @@ var config = {
 }
 var board = Chessboard2('myBoard', config)
 
-$('#flipOrientationBtn').on('click', board.flip)
+attachEvent('flipOrientationBtn', 'click', board.flip)

--- a/examples/4012-onmoveend.example
+++ b/examples/4012-onmoveend.example
@@ -28,11 +28,11 @@ var config = {
 }
 var board = Chessboard2('myBoard', config)
 
-$('#ruyLopezBtn').on('click', function () {
+attachEvent('ruyLopezBtn', 'click', function () {
   board.position('r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R')
 })
-$('#moveBtn').on('click', function () {
+attachEvent('moveBtn', 'click', function () {
   board.move('a2-a4', 'h7-h5')
 })
-$('#startBtn').on('click', board.start)
-$('#clearBtn').on('click', board.clear)
+attachEvent('startBtn', 'click', board.start)
+attachEvent('clearBtn', 'click', board.clear)

--- a/examples/5000-legal-moves.example
+++ b/examples/5000-legal-moves.example
@@ -20,11 +20,10 @@ You can integrate chessboard.js with the <a href="https://github.com/jhlywa/ches
 // NOTE: this example uses the chess.js library:
 // https://github.com/jhlywa/chess.js
 
-var board = null
 var game = new Chess()
-var $status = $('#status')
-var $fen = $('#fen')
-var $pgn = $('#pgn')
+var $status = document.querySelector('#status')
+var $fen = document.querySelector('#fen')
+var $pgn = document.querySelector('#pgn')
 
 function onDragStart (source, piece, position, orientation) {
   // do not pick up pieces if the game is over
@@ -68,15 +67,13 @@ function updateStatus () {
   // checkmate?
   if (game.in_checkmate()) {
     status = 'Game over, ' + moveColor + ' is in checkmate.'
-  }
-
+  
   // draw?
-  else if (game.in_draw()) {
+  } else if (game.in_draw()) {
     status = 'Game over, drawn position'
-  }
 
   // game still on
-  else {
+  } else {
     status = moveColor + ' to move'
 
     // check?
@@ -97,6 +94,6 @@ var config = {
   onDrop: onDrop,
   onSnapEnd: onSnapEnd
 }
-board = Chessboard2('myBoard', config)
+const board = Chessboard2('myBoard', config)
 
 updateStatus()

--- a/examples/5001-play-random-computer.example
+++ b/examples/5001-play-random-computer.example
@@ -64,14 +64,14 @@ function onTouchSquare (square, piece, boardInfo) {
     legalMoves.forEach(move => {
       board.addCircle(move.to)
     })
-  }
+
   // Option 2: clear a pending move if the user selects the same square twice
-  else if (pendingMove && pendingMove === square) {
+  } else if (pendingMove && pendingMove === square) {
     pendingMove = null
     board.clearCircles()
-  }
+  
   // Option 3: clear a pending move and start a new pending move
-  else if (pendingMove) {
+  } else if (pendingMove) {
     // ask chess.js to make a move
     const moveResult = game.move({
       from: pendingMove,
@@ -92,9 +92,9 @@ function onTouchSquare (square, piece, boardInfo) {
         // wait a smidge, then make a random move for Black
         window.setTimeout(makeRandomMove, 250)
       })
-    }
+    
     // if the move was not legal, then start a new pendingMove from this square
-    else if (piece) {
+    } else if (piece) {
       pendingMove = square
 
       // remove any previous circles
@@ -104,9 +104,9 @@ function onTouchSquare (square, piece, boardInfo) {
       legalMoves.forEach(m => {
         board.addCircle(m.to)
       })
-    }
+    
     // else clear pendingMove
-    else {
+    } else {
       pendingMove = null
       board.clearCircles()
     }

--- a/examples/5002-random-vs-random.example
+++ b/examples/5002-random-vs-random.example
@@ -14,7 +14,6 @@ Who will win in this riveting game of <code class="js plain">Math.random()</code
 // NOTE: this example uses the chess.js library:
 // https://github.com/jhlywa/chess.js
 
-var board = null
 var game = new Chess()
 
 function makeRandomMove () {
@@ -30,6 +29,6 @@ function makeRandomMove () {
   window.setTimeout(makeRandomMove, 500)
 }
 
-board = Chessboard2('myBoard', 'start')
+const board = Chessboard2('myBoard', 'start')
 
 window.setTimeout(makeRandomMove, 500)

--- a/examples/5003-highlight-legal-moves.example
+++ b/examples/5003-highlight-legal-moves.example
@@ -14,17 +14,16 @@ Use the <code class="js plain"><a href="docs.html#config:onMouseoverSquare">onMo
 // NOTE: this example uses the chess.js library:
 // https://github.com/jhlywa/chess.js
 
-var board = null
 var game = new Chess()
 var whiteSquareGrey = '#a9a9a9'
 var blackSquareGrey = '#696969'
 
 function removeGreySquares () {
-  $('#myBoard .square-55d63').css('background', '')
+  document.querySelector('#myBoard .square-55d63').style.background = ''
 }
 
 function greySquare (square) {
-  var $square = $('#myBoard .square-' + square)
+  var $square = document.querySelector('#myBoard .square-' + square)
 
   var background = whiteSquareGrey
   if ($square.hasClass('black-3c85d')) {
@@ -95,4 +94,4 @@ var config = {
   onMouseoverSquare: onMouseoverSquare,
   onSnapEnd: onSnapEnd
 }
-board = Chessboard2('myBoard', config)
+const board = Chessboard2('myBoard', config)

--- a/examples/5004-piece-highlight1.example
+++ b/examples/5004-piece-highlight1.example
@@ -22,8 +22,7 @@ Use CSS to show piece highlighting.
 // NOTE: this example uses the chess.js library:
 // https://github.com/jhlywa/chess.js
 
-var board = null
-var $board = $('#myBoard')
+var $board = document.querySelector('#myBoard')
 var game = new Chess()
 var squareClass = 'square-55d63'
 var squareToHighlight = null
@@ -67,6 +66,6 @@ var config = {
   position: 'start',
   onMoveEnd: onMoveEnd
 }
-board = Chessboard2('myBoard', config)
+const board = Chessboard2('myBoard', config)
 
 window.setTimeout(makeRandomMove, 500)

--- a/examples/5005-piece-highlight2.example
+++ b/examples/5005-piece-highlight2.example
@@ -22,8 +22,7 @@ Use CSS to show piece highlighting.
 // NOTE: this example uses the chess.js library:
 // https://github.com/jhlywa/chess.js
 
-var board = null
-var $board = $('#myBoard')
+var $board = document.querySelector('#myBoard')
 var game = new Chess()
 var squareToHighlight = null
 var squareClass = 'square-55d63'
@@ -101,4 +100,4 @@ var config = {
   onMoveEnd: onMoveEnd,
   onSnapEnd: onSnapEnd
 }
-board = Chessboard2('myBoard', config)
+const board = Chessboard2('myBoard', config)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build-report": "shadow-cljs run shadow.cljs.build-report chessboard2 website/build-report.html",
     "build": "shadow-cljs release chessboard2 && ./scripts/website.js",
     "cypress": "cypress open",
+    "lint-examples": "./scripts/lint-examples.js",
     "local-dev": "serve website/ -p 3232",
     "release": "shadow-cljs release chessboard2 && ./scripts/release.js",
     "standard-fix": "standard --fix scripts/ website/js/examples.js",

--- a/scripts/lint-examples.js
+++ b/scripts/lint-examples.js
@@ -11,25 +11,57 @@ const fs = require('fs-plus')
 const kidif = require('kidif')
 const path = require('path')
 
-fs.removeSync('tmp')
-fs.makeTreeSync('tmp')
+fs.removeSync('tmp-linting')
+fs.makeTreeSync('tmp-linting')
 
 // grab the examples
-const examplesArr = kidif('examples/*.example')
+const examplesArr = kidif('examples/*.example',{camelCaseTitles: false})
 
 // sanity check the examples
 assert(examplesArr, 'Could not load the Example files')
 assert(examplesArr.length > 1, 'Zero examples loaded')
 
+// create temporary js files for linting
 examplesArr.forEach((example) => {
-  fs.writeFileSync(path.join('tmp', example.id + '.js'), example.js)
+  const tmpPath = path.join('tmp-linting', example.id + '.js')
+  fs.writeFileSync(tmpPath, example.JS)
 })
 
-const output = childProcess.execSync('npx standard --fix tmp/', {
-  cwd: path.join(__dirname, '..'),
-  encoding: 'utf8'
+// run linter on temporary folder
+// standard throws errors on non-fixable issues, so log the error
+try{
+  const output = childProcess.execSync(`npx standard --global attachEvent --global Chess --global Chessboard --global Chessboard2 --fix tmp-linting/`, {
+    cwd: path.join(__dirname, '..'),
+    encoding: 'utf8'
+  })
+  console.log(output.stdOut)
+} catch (err) {
+  console.error(err)
+}
+
+// loop over all examples, match up lintedJS for each, and re-write the example
+fs.readdirSync('./examples/').forEach( (file) => {
+  const originalExamplesArr = kidif(`examples/${file}`,{camelCaseTitles: false})
+  const originalExample = originalExamplesArr[0]
+  
+  if(originalExamplesArr.length === 1 && originalExample.id && originalExample.JS) {
+    const lintedJS = fs.readFileSync(`tmp-linting/${originalExample.id}.js`).toString()
+    assert(lintedJS.length > 0)
+
+    let outputString = ''
+
+    const lastKeyIndex = Object.keys(originalExample).length - 1
+    Object.entries(originalExample).forEach(([key, originalValue],idx) => {
+      outputString += `===== ${key}\n` +
+                      `${key === "JS" ? lintedJS : originalValue}`
+      if(idx < lastKeyIndex) {
+        outputString += '\n\n'
+      }
+    })
+
+    fs.writeFileSync(`./examples/${file}`,outputString)
+  }
 })
 
-console.log(output.stdout)
-
-fs.removeSync('tmp')
+// delete temporary linting directory
+fs.removeSync('tmp-linting')


### PR DESCRIPTION
- remove jQuery from examples
- some preemptive changes addressing "standardjs" linting errors
  - ex: closing brace `}` before else blocks
- finish the lint-examples script
  - add lint-examples to package.json

### NOTE:

I didn't run the linter in this PR, but when it is run, there are a bunch of CRLF => LF changes which will show up in diff (actually, some showed up already, but the first linting will almost look like a full file edit for most examples files)