### PR TITLE
Click create arrows example

### DIFF
--- a/examples/5006-click-to-create-arrows.example
+++ b/examples/5006-click-to-create-arrows.example
@@ -1,0 +1,60 @@
+===== id
+5006-click-to-create-arrows
+
+===== Name
+Click to Create Arrows
+
+===== DescriptionMD
+Click on squares to create analysis arrows.
+
+===== HTML
+<div id="myBoard" style="width: 400px"></div>
+
+<button id="clearArrowsBtn">Clear Arrows</button>
+<button id="logArrowsBtn">console.log Arrows</button>
+
+===== JS
+let pendingArrow = null
+
+const board = window.Chessboard2('myBoard', {
+  onMousedownSquare: onMousedownSquare
+})
+
+function onMousedownSquare (evt, domEvt) {
+  // clear any circles that may be on the board
+  board.clearCircles()
+
+  // do we have a pending arrow?
+  if (pendingArrow) {
+    // add an arrow to the board
+    board.addArrow({
+      start: pendingArrow,
+      end: evt.square
+    })
+    // clear the pendingArrow
+    pendingArrow = null
+  } else {
+    // store the pending arrow info
+    pendingArrow = evt.square
+
+    // put a circle on the square
+    board.addCircle(evt.square)
+  }
+}
+
+attachEvent('clearArrowsBtn', 'click', () => {
+  board.clearArrows()
+})
+
+attachEvent('logArrowsBtn', 'click', () => {
+  console.log('Arrows Array:')
+  console.log(board.getArrows())
+
+  console.log('Arrows Object:')
+  console.log(board.getArrows('object'))
+
+  console.log('Arrows Map:')
+  console.log(board.getArrows('map'))
+
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+})

--- a/examples/5007-click-to-create-arrows-preview.example
+++ b/examples/5007-click-to-create-arrows-preview.example
@@ -1,0 +1,79 @@
+===== id
+5007-click-to-create-arrows-preview
+
+===== Name
+Click to Create Arrows Preview on Square
+
+===== DescriptionMD
+Click on squares to create analysis arrows. Show a preview of the arrow using the onMouseenterSquare event.
+
+===== HTML
+<div id="myBoard" style="width: 400px"></div>
+
+<button id="clearArrowsBtn">Clear Arrows</button>
+<button id="logArrowsBtn">console.log Arrows</button>
+
+===== JS
+let pendingArrow = null
+let tmpArrowId = null
+
+const board = window.Chessboard2('myBoard', {
+  onMousedownSquare: onMousedownSquare,
+  onMouseenterSquare: onMouseenterSquare
+})
+
+function onMousedownSquare (evt, domEvt) {
+  // clear any circles that may be on the board
+  board.clearCircles()
+
+  // do we have a pending arrow?
+  if (pendingArrow) {
+    // add an arrow to the board
+    board.addArrow({
+      start: pendingArrow,
+      end: evt.square
+    })
+
+    // clear the pending and tmp arrows
+    pendingArrow = null
+    board.removeArrow(tmpArrowId)
+    tmpArrowId = null
+  } else {
+    // store the pending arrow info
+    pendingArrow = evt.square
+
+    // put a circle on the starting square
+    board.addCircle(evt.square)
+  }
+}
+
+function onMouseenterSquare (evt, domEvt) {
+  // do nothing if we are not pending an Arrow
+  if (!pendingArrow) return
+
+  if (tmpArrowId) {
+    board.removeArrow(tmpArrowId)
+  }
+
+  tmpArrowId = board.addArrow({
+    start: pendingArrow,
+    end: evt.square
+  })
+}
+
+attachEvent('clearArrowsBtn', 'click', () => {
+  board.clearArrows()
+})
+
+attachEvent('logArrowsBtn', 'click', () => {
+  console.log('Arrows Array:')
+  console.log(board.getArrows())
+
+  console.log('Arrows Object:')
+  console.log(board.getArrows('object'))
+
+  console.log('Arrows Map:')
+  console.log(board.getArrows('map'))
+
+  console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+})

--- a/src-cljs/com/oakmac/chessboard2/config.cljs
+++ b/src-cljs/com/oakmac/chessboard2/config.cljs
@@ -54,6 +54,9 @@
    :onDrop
    {:valid-fn fn?}
 
+   :onMousedownSquare
+   {:valid-fn fn?}
+
    :onSnapEnd
    {:valid-fn fn?}
 

--- a/src-cljs/com/oakmac/chessboard2/config.cljs
+++ b/src-cljs/com/oakmac/chessboard2/config.cljs
@@ -57,6 +57,17 @@
    :onMousedownSquare
    {:valid-fn fn?}
 
+   ;; TODO: implement me
+   ; :onMouseupSquare
+   ; {:valid-fn fn?}
+
+   :onMouseenterSquare
+   {:valid-fn fn?}
+
+   ;; TODO: implement me
+   ; :onMouseleaveSquare
+   ; {:valid-fn fn?}
+
    :onSnapEnd
    {:valid-fn fn?}
 

--- a/src-cljs/com/oakmac/chessboard2/core.cljs
+++ b/src-cljs/com/oakmac/chessboard2/core.cljs
@@ -164,13 +164,12 @@
     ;; return null
     nil))
 
-;; FIXME: this function should support onMouseDown instead of onTouchSquare
 (defn on-mouse-down
   "This function fires on every 'mousedown' event inside the root DOM element"
   [board-state js-evt]
   (dom-util/safe-prevent-default js-evt)
-  (let [{:keys [draggable mouseDraggable onTouchSquare orientation position root-el square->piece-id square->square-ids touchMove]} @board-state
-        target-el (gobj/get js-evt "target")
+  (let [{:keys [draggable mouseDraggable onMousedownSquare orientation position _square->piece-id square->square-ids touchMove]} @board-state
+        ; target-el (gobj/get js-evt "target")
         clientX (gobj/get js-evt "clientX")
         clientY (gobj/get js-evt "clientY")
 
@@ -183,11 +182,13 @@
         ;; NOTE: piece may be nil if there is no piece on the square they touched
         piece (get position square)
 
-        ;; call their onTouchSquare function if provided
-        on-touchsquare-result (when (fn? onTouchSquare)
-                                (let [js-board-info (js-obj "orientation" orientation
-                                                            "position" (clj->js position))]
-                                  (onTouchSquare square piece js-board-info)))]
+        ;; call their onMousedownSquare function if provided
+        on-mousedown-result (when (fn? onMousedownSquare)
+                              (let [js-board-info (js-obj "orientation" orientation
+                                                          "piece" piece
+                                                          "position" (clj->js position)
+                                                          "square" square)]
+                                (onMousedownSquare js-board-info js-evt)))]
 
     ;; begin dragging if configured
     (when (and piece
@@ -196,7 +197,7 @@
 
     ;; highlight the square and queue a move if touchmove is enabled
     (when (and (true? touchMove)
-               (not (false? on-touchsquare-result))
+               (not (false? on-mousedown-result))
                piece))
       ;; FIXME:
       ;; - highlight the square here?

--- a/src-cljs/com/oakmac/chessboard2/core.cljs
+++ b/src-cljs/com/oakmac/chessboard2/core.cljs
@@ -204,39 +204,6 @@
     ;; return null
     nil))
 
-(defn on-mouseenter-square
-  "This function fires on every 'mouseenter' event on a Square element"
-  [board-state square-id js-evt]
-
-  (js/console.log "mouse enter square:" square-id)
-
-  ;; FIXME: assert that square-id is in board-state (it definitely should be)
-  (dom-util/safe-prevent-default js-evt)
-  (let [{:keys [draggable mouseDraggable onMouseenterSquare orientation position _square->piece-id square->square-ids touchMove]} @board-state
-        ; target-el (gobj/get js-evt "target")
-        clientX (gobj/get js-evt "clientX")
-        clientY (gobj/get js-evt "clientY")
-
-        square (xy->square clientX clientY square->square-ids)
-
-        _ (when flags/runtime-checks?
-            (when-not (valid-square? square)
-              (error-log "Invalid square in on-mouseenter-square:" square)))
-
-        ;; NOTE: piece may be nil if there is no piece on the square they touched
-        piece (get position square)]
-
-    ;; call their onMouseenterSquare function if provided
-    (when (fn? onMouseenterSquare)
-      (let [js-board-info (js-obj "orientation" orientation
-                                  "piece" piece
-                                  "position" (clj->js position)
-                                  "square" square)]
-        (onMouseenterSquare js-board-info js-evt)))
-
-    ;; return null
-    nil))
-
 (defn update-dragging-piece-position!
   "Update the x, y coordinates of the dragging piece on the next animationFrame"
   [dragging-el x y]


### PR DESCRIPTION
re: [Issue #40](https://github.com/oakmac/chessboard2/issues/40)

* add `onMousedownSquare` event
* add `onMouseenterSquare` event
* add examples of dynamically creating arrows on the board (Example 5006 and 5007)